### PR TITLE
Fix Client Display Issues

### DIFF
--- a/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
+++ b/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
@@ -27,9 +27,7 @@ public class SlimeItemLayer<T extends Entity> extends LayerRenderer<T, SlimeMode
             stack.rotate(Vector3f.XP.rotationDegrees(180));
             stack.translate(0, -1, 0);
             stack.rotate(Vector3f.XP.rotationDegrees(90));
-            float angle = entity.rotationYaw;
-            stack.rotate(Vector3f.ZN.rotationDegrees(angle));
-            stack.translate(0, -(2 * 0.0626), 0);
+            stack.translate(0, -(4 * 0.0626), 0);
             stack.translate(0, 0, -0.0626 / 4);
             stack.rotate(Vector3f.YP.rotationDegrees(90));
             Minecraft.getInstance().getItemRenderer().renderItem(ItemStack.read(entity.getPersistentData().getCompound("AbsorbedItem")), ItemCameraTransforms.TransformType.GROUND, p_225628_3_, OverlayTexture.NO_OVERLAY, stack, type);

--- a/src/main/java/com/blamejared/slimyboyos/events/ClientEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/ClientEventHandler.java
@@ -3,7 +3,6 @@ package com.blamejared.slimyboyos.events;
 import com.blamejared.slimyboyos.client.render.SlimeItemLayer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.*;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.RecipesUpdatedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -13,7 +12,7 @@ public class ClientEventHandler {
     @SubscribeEvent
     public void recipeUpdated(RecipesUpdatedEvent e) {
         EntityRendererManager manager = Minecraft.getInstance().getRenderManager();
-        ForgeRegistries.ENTITIES.getValues().stream().filter(entityType -> entityType.getTags().contains(new ResourceLocation("forge:slimes"))).map(manager.renderers::get).filter(entityRenderer -> entityRenderer instanceof MobRenderer).map(entityRenderer -> (MobRenderer) entityRenderer).forEach(mobRenderer -> {
+        ForgeRegistries.ENTITIES.getValues().stream().filter(entityType -> entityType.getTags().contains(CommonEventHandler.SLIMES)).map(manager.renderers::get).filter(entityRenderer -> entityRenderer instanceof MobRenderer).map(entityRenderer -> (MobRenderer) entityRenderer).forEach(mobRenderer -> {
             mobRenderer.addLayer(new SlimeItemLayer(mobRenderer));
         });
     }


### PR DESCRIPTION
- Fix rotation such that the block doesn't move sporadically when rotating.
- Update client handler to use already declared resource location.
- Add game rule to not drop stack unless `DO_ENTITY_DROPS` is true
- Change packet distributor to `TRACKING_ENTITY` (it makes the most logical sense)
- Send packet to players who start to track the entity. Fixes any issues with entities who pick up an item while a different player is not viewing it.