### PR TITLE
Switch over to Capabilities & Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ out
 .idea
 
 # gradle
+logs
 build
 .gradle
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ minecraft {
         data {
             workingDirectory project.file('run')
 
-            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
+            args '--mod', 'slimyboyos', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
 
             mods {
                 slimyboyos {
@@ -72,6 +72,8 @@ minecraft {
         }
     }
 }
+
+sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 task genGitChangelog() {
     def stdout = new ByteArrayOutputStream()

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ if (project.hasProperty('secretFile')) {
     loadSecrets(new File((String) findProperty('secretFile')))
 }
 
-version = "3.0.0"
+version = "3.1.0"
 if (System.getenv('BUILD_NUMBER') != null) {
     version += "." + System.getenv('BUILD_NUMBER')
 }
@@ -37,7 +37,7 @@ repositories {
 }
 minecraft {
     mappings channel: 'snapshot', version: '20200820-1.16.1'
-    accessTransformer = file('src/main/resources/META-INF/slime_at.cfg')
+    //accessTransformer = file('src/main/resources/META-INF/slime_at.cfg')
     runs {
         client {
             workingDirectory project.file('run')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
+org.gradle.daemon=false

--- a/src/main/java/com/blamejared/slimyboyos/SlimyBoyos.java
+++ b/src/main/java/com/blamejared/slimyboyos/SlimyBoyos.java
@@ -1,5 +1,6 @@
 package com.blamejared.slimyboyos;
 
+import com.blamejared.slimyboyos.capability.SlimeAbsorptionCapability;
 import com.blamejared.slimyboyos.events.ClientEventHandler;
 import com.blamejared.slimyboyos.events.CommonEventHandler;
 import com.blamejared.slimyboyos.network.PacketHandler;
@@ -24,6 +25,7 @@ public class SlimyBoyos {
 
     private void setup(final FMLCommonSetupEvent event) {
         PacketHandler.init();
+        SlimeAbsorptionCapability.init();
     }
 
     private void doClientStuff(final FMLClientSetupEvent event) {

--- a/src/main/java/com/blamejared/slimyboyos/SlimyBoyos.java
+++ b/src/main/java/com/blamejared/slimyboyos/SlimyBoyos.java
@@ -1,28 +1,32 @@
 package com.blamejared.slimyboyos;
 
-import com.blamejared.slimyboyos.events.*;
+import com.blamejared.slimyboyos.events.ClientEventHandler;
+import com.blamejared.slimyboyos.events.CommonEventHandler;
 import com.blamejared.slimyboyos.network.PacketHandler;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.*;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 
 @Mod("slimyboyos")
 public class SlimyBoyos {
-    
+
+    public static final ResourceLocation SLIMES = new ResourceLocation("forge:slimes");
+
     public SlimyBoyos() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::doClientStuff);
         MinecraftForge.EVENT_BUS.register(new CommonEventHandler());
     }
+
     private void setup(final FMLCommonSetupEvent event) {
         PacketHandler.init();
     }
-    
+
     private void doClientStuff(final FMLClientSetupEvent event) {
         MinecraftForge.EVENT_BUS.register(new ClientEventHandler());
     }
-    
-    
 }

--- a/src/main/java/com/blamejared/slimyboyos/SlimyBoyos.java
+++ b/src/main/java/com/blamejared/slimyboyos/SlimyBoyos.java
@@ -4,7 +4,6 @@ import com.blamejared.slimyboyos.capability.SlimeAbsorptionCapability;
 import com.blamejared.slimyboyos.events.ClientEventHandler;
 import com.blamejared.slimyboyos.events.CommonEventHandler;
 import com.blamejared.slimyboyos.network.PacketHandler;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -14,8 +13,6 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod("slimyboyos")
 public class SlimyBoyos {
-
-    public static final ResourceLocation SLIMES = new ResourceLocation("forge:slimes");
 
     public SlimyBoyos() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);

--- a/src/main/java/com/blamejared/slimyboyos/capability/SlimeAbsorption.java
+++ b/src/main/java/com/blamejared/slimyboyos/capability/SlimeAbsorption.java
@@ -1,0 +1,84 @@
+package com.blamejared.slimyboyos.capability;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.common.util.LazyOptional;
+
+public interface SlimeAbsorption extends INBTSerializable<CompoundNBT> {
+
+    ItemStack getAbsorbedStack();
+
+    void setAbsorbedStack(ItemStack stack);
+
+    class Impl implements SlimeAbsorption {
+
+        private ItemStack absorbedStack;
+
+        public Impl() {
+            this(ItemStack.EMPTY);
+        }
+
+        public Impl(ItemStack absorbedStack) {
+            this.absorbedStack = absorbedStack;
+        }
+
+        @Override
+        public ItemStack getAbsorbedStack() {
+            return absorbedStack;
+        }
+
+        @Override
+        public void setAbsorbedStack(ItemStack stack) {
+            this.absorbedStack = stack;
+        }
+
+        @Override
+        public CompoundNBT serializeNBT() {
+            CompoundNBT nbt = new CompoundNBT();
+            if (!absorbedStack.isEmpty()) {
+                absorbedStack.write(nbt);
+            }
+            return nbt;
+        }
+
+        @Override
+        public void deserializeNBT(CompoundNBT nbt) {
+            if (nbt.isEmpty()) {
+                absorbedStack = ItemStack.EMPTY;
+            } else {
+                absorbedStack = ItemStack.read(nbt);
+            }
+        }
+    }
+
+    class Provider implements ICapabilitySerializable<CompoundNBT> {
+
+        public static final ResourceLocation NAME = new ResourceLocation("slimyboyos:slime_absorption");
+
+        private final SlimeAbsorption impl = new Impl();
+        private final LazyOptional<SlimeAbsorption> cap = LazyOptional.of(() -> impl);
+
+        @Override
+        public <T> LazyOptional<T> getCapability(Capability<T> capability, Direction facing) {
+            if (capability == SlimeAbsorptionCapability.SLIME_ABSORPTION) {
+                return cap.cast();
+            }
+            return LazyOptional.empty();
+        }
+
+        @Override
+        public CompoundNBT serializeNBT() {
+            return impl.serializeNBT();
+        }
+
+        @Override
+        public void deserializeNBT(CompoundNBT nbt) {
+            impl.deserializeNBT(nbt);
+        }
+    }
+}

--- a/src/main/java/com/blamejared/slimyboyos/capability/SlimeAbsorptionCapability.java
+++ b/src/main/java/com/blamejared/slimyboyos/capability/SlimeAbsorptionCapability.java
@@ -1,20 +1,11 @@
 package com.blamejared.slimyboyos.capability;
 
-import com.blamejared.slimyboyos.SlimyBoyos;
-import com.blamejared.slimyboyos.network.MessageItemSync;
-import com.blamejared.slimyboyos.network.PacketHandler;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.INBT;
 import net.minecraft.util.Direction;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.CapabilityManager;
-import net.minecraftforge.event.AttachCapabilitiesEvent;
-import net.minecraftforge.event.entity.player.PlayerEvent;
-import net.minecraftforge.fml.network.PacketDistributor;
 
 
 public class SlimeAbsorptionCapability {
@@ -39,28 +30,5 @@ public class SlimeAbsorptionCapability {
                     }
                 },
                 SlimeAbsorption.Impl::new);
-
-        MinecraftForge.EVENT_BUS.addGenericListener(Entity.class, SlimeAbsorptionCapability::attachCapabilities);
-        MinecraftForge.EVENT_BUS.addListener(SlimeAbsorptionCapability::onStartTracking);
-    }
-
-    private static void attachCapabilities(AttachCapabilitiesEvent<Entity> event) {
-        Entity e = event.getObject();
-        if (e.getType().getTags().contains(SlimyBoyos.SLIMES)) {
-            event.addCapability(SlimeAbsorption.Provider.NAME, new SlimeAbsorption.Provider());
-        }
-    }
-
-    private static void onStartTracking(PlayerEvent.StartTracking event) {
-        if (!(event.getPlayer() instanceof ServerPlayerEntity) || !event.getTarget().isAlive()) {
-            return;
-        }
-
-        event.getTarget().getCapability(SLIME_ABSORPTION).ifPresent(
-                slimeAbsorption -> PacketHandler.CHANNEL.send(
-                        PacketDistributor.PLAYER.with(() -> (ServerPlayerEntity) event.getPlayer()),
-                        new MessageItemSync(event.getTarget().getEntityId(), slimeAbsorption.getAbsorbedStack())
-                )
-        );
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/capability/SlimeAbsorptionCapability.java
+++ b/src/main/java/com/blamejared/slimyboyos/capability/SlimeAbsorptionCapability.java
@@ -1,0 +1,66 @@
+package com.blamejared.slimyboyos.capability;
+
+import com.blamejared.slimyboyos.SlimyBoyos;
+import com.blamejared.slimyboyos.network.MessageItemSync;
+import com.blamejared.slimyboyos.network.PacketHandler;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.INBT;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.network.PacketDistributor;
+
+
+public class SlimeAbsorptionCapability {
+
+    @CapabilityInject(SlimeAbsorption.class)
+    public static Capability<SlimeAbsorption> SLIME_ABSORPTION;
+
+    public static void init() {
+        CapabilityManager.INSTANCE.register(SlimeAbsorption.class, new Capability.IStorage<SlimeAbsorption>() {
+                    @Override
+                    public INBT writeNBT(Capability<SlimeAbsorption> capability, SlimeAbsorption instance,
+                                         Direction side) {
+                        return instance.serializeNBT();
+                    }
+
+                    @Override
+                    public void readNBT(Capability<SlimeAbsorption> capability, SlimeAbsorption instance,
+                                        Direction side, INBT nbt) {
+                        if (nbt instanceof CompoundNBT) {
+                            instance.deserializeNBT((CompoundNBT) nbt);
+                        }
+                    }
+                },
+                SlimeAbsorption.Impl::new);
+
+        MinecraftForge.EVENT_BUS.addGenericListener(Entity.class, SlimeAbsorptionCapability::attachCapabilities);
+        MinecraftForge.EVENT_BUS.addListener(SlimeAbsorptionCapability::onStartTracking);
+    }
+
+    private static void attachCapabilities(AttachCapabilitiesEvent<Entity> event) {
+        Entity e = event.getObject();
+        if (e.getType().getTags().contains(SlimyBoyos.SLIMES)) {
+            event.addCapability(SlimeAbsorption.Provider.NAME, new SlimeAbsorption.Provider());
+        }
+    }
+
+    private static void onStartTracking(PlayerEvent.StartTracking event) {
+        if (!(event.getPlayer() instanceof ServerPlayerEntity) || !event.getTarget().isAlive()) {
+            return;
+        }
+
+        event.getTarget().getCapability(SLIME_ABSORPTION).ifPresent(
+                slimeAbsorption -> PacketHandler.CHANNEL.send(
+                        PacketDistributor.PLAYER.with(() -> (ServerPlayerEntity) event.getPlayer()),
+                        new MessageItemSync(event.getTarget().getEntityId(), slimeAbsorption.getAbsorbedStack())
+                )
+        );
+    }
+}

--- a/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
+++ b/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
@@ -34,8 +34,6 @@ public class SlimeItemLayer<T extends Entity> extends LayerRenderer<T, SlimeMode
                     stack.rotate(Vector3f.XP.rotationDegrees(180));
                     stack.translate(0, -1, 0);
                     stack.rotate(Vector3f.XP.rotationDegrees(90));
-                    float angle = entity.rotationYaw;
-                    stack.rotate(Vector3f.ZN.rotationDegrees(angle));
                     stack.translate(0, -(2 * 0.0626), 0);
                     stack.translate(0, 0, -0.0626 / 4);
                     stack.rotate(Vector3f.YP.rotationDegrees(90));

--- a/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
+++ b/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
@@ -27,9 +27,7 @@ public class SlimeItemLayer<T extends Entity> extends LayerRenderer<T, SlimeMode
             stack.rotate(Vector3f.XP.rotationDegrees(180));
             stack.translate(0, -1, 0);
             stack.rotate(Vector3f.XP.rotationDegrees(90));
-            float angle = entity.rotationYaw;
-            stack.rotate(Vector3f.ZN.rotationDegrees(angle));
-            stack.translate(0, -(2 * 0.0626), 0);
+            stack.translate(0, -(4 * 0.0626), 0);
             stack.translate(0, 0, -0.0626 / 4);
             stack.rotate(Vector3f.YP.rotationDegrees(90));
             Minecraft.getInstance().getItemRenderer().renderItem(ItemStack.read(entity.getPersistentData().getCompound("AbsorbedItem")), ItemCameraTransforms.TransformType.GROUND, p_225628_3_, OverlayTexture.NO_OVERLAY, stack, type);

--- a/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
+++ b/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
@@ -10,30 +10,41 @@ import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.vector.Vector3f;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.util.Constants;
 
 @OnlyIn(Dist.CLIENT)
 public class SlimeItemLayer<T extends Entity> extends LayerRenderer<T, SlimeModel<T>> {
-    
-    public SlimeItemLayer(IEntityRenderer<T, SlimeModel<T>> p_i50923_1_) {
-        super(p_i50923_1_);
+
+    public SlimeItemLayer(IEntityRenderer<T, SlimeModel<T>> renderer) {
+        super(renderer);
     }
-    
-    public void render(MatrixStack stack, IRenderTypeBuffer type, int p_225628_3_, T entity, float p_225628_5_, float p_225628_6_, float p_225628_7_, float p_225628_8_, float p_225628_9_, float p_225628_10_) {
-        if(!entity.isInvisible() && entity.getPersistentData().contains("AbsorbedItem") && entity.isAlive()) {
-            stack.push();
-            stack.rotate(Vector3f.XP.rotationDegrees(180));
-            stack.translate(0, -1, 0);
-            stack.rotate(Vector3f.XP.rotationDegrees(90));
-            float angle = entity.rotationYaw;
-            stack.rotate(Vector3f.ZN.rotationDegrees(angle));
-            stack.translate(0, -(2 * 0.0626), 0);
-            stack.translate(0, 0, -0.0626 / 4);
-            stack.rotate(Vector3f.YP.rotationDegrees(90));
-            Minecraft.getInstance().getItemRenderer().renderItem(ItemStack.read(entity.getPersistentData().getCompound("AbsorbedItem")), ItemCameraTransforms.TransformType.GROUND, p_225628_3_, OverlayTexture.NO_OVERLAY, stack, type);
-            stack.pop();
+
+    public void render(MatrixStack stack, IRenderTypeBuffer type, int p_225628_3_, T entity, float p_225628_5_,
+                       float p_225628_6_, float p_225628_7_, float p_225628_8_, float p_225628_9_, float p_225628_10_) {
+        if (entity.isAlive() && !entity.isInvisible()) {
+            CompoundNBT data = entity.getPersistentData();
+            if (data.contains("AbsorbedItem", Constants.NBT.TAG_COMPOUND)) {
+                ItemStack itemStack = ItemStack.read(data.getCompound("AbsorbedItem"));
+                if (!itemStack.isEmpty()) {
+                    stack.push();
+                    stack.rotate(Vector3f.XP.rotationDegrees(180));
+                    stack.translate(0, -1, 0);
+                    stack.rotate(Vector3f.XP.rotationDegrees(90));
+                    float angle = entity.rotationYaw;
+                    stack.rotate(Vector3f.ZN.rotationDegrees(angle));
+                    stack.translate(0, -(2 * 0.0626), 0);
+                    stack.translate(0, 0, -0.0626 / 4);
+                    stack.rotate(Vector3f.YP.rotationDegrees(90));
+                    Minecraft.getInstance().getItemRenderer().renderItem(itemStack,
+                            ItemCameraTransforms.TransformType.GROUND, p_225628_3_, OverlayTexture.NO_OVERLAY, stack,
+                            type);
+                    stack.pop();
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
+++ b/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
@@ -10,28 +10,41 @@ import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.vector.Vector3f;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.util.Constants;
 
 @OnlyIn(Dist.CLIENT)
 public class SlimeItemLayer<T extends Entity> extends LayerRenderer<T, SlimeModel<T>> {
-    
-    public SlimeItemLayer(IEntityRenderer<T, SlimeModel<T>> p_i50923_1_) {
-        super(p_i50923_1_);
+
+    public SlimeItemLayer(IEntityRenderer<T, SlimeModel<T>> renderer) {
+        super(renderer);
     }
-    
-    public void render(MatrixStack stack, IRenderTypeBuffer type, int p_225628_3_, T entity, float p_225628_5_, float p_225628_6_, float p_225628_7_, float p_225628_8_, float p_225628_9_, float p_225628_10_) {
-        if(!entity.isInvisible() && entity.getPersistentData().contains("AbsorbedItem") && entity.isAlive()) {
-            stack.push();
-            stack.rotate(Vector3f.XP.rotationDegrees(180));
-            stack.translate(0, -1, 0);
-            stack.rotate(Vector3f.XP.rotationDegrees(90));
-            stack.translate(0, -(4 * 0.0626), 0);
-            stack.translate(0, 0, -0.0626 / 4);
-            stack.rotate(Vector3f.YP.rotationDegrees(90));
-            Minecraft.getInstance().getItemRenderer().renderItem(ItemStack.read(entity.getPersistentData().getCompound("AbsorbedItem")), ItemCameraTransforms.TransformType.GROUND, p_225628_3_, OverlayTexture.NO_OVERLAY, stack, type);
-            stack.pop();
+
+    public void render(MatrixStack stack, IRenderTypeBuffer type, int p_225628_3_, T entity, float p_225628_5_,
+                       float p_225628_6_, float p_225628_7_, float p_225628_8_, float p_225628_9_, float p_225628_10_) {
+        if (entity.isAlive() && !entity.isInvisible()) {
+            CompoundNBT data = entity.getPersistentData();
+            if (data.contains("AbsorbedItem", Constants.NBT.TAG_COMPOUND)) {
+                ItemStack itemStack = ItemStack.read(data.getCompound("AbsorbedItem"));
+                if (!itemStack.isEmpty()) {
+                    stack.push();
+                    stack.rotate(Vector3f.XP.rotationDegrees(180));
+                    stack.translate(0, -1, 0);
+                    stack.rotate(Vector3f.XP.rotationDegrees(90));
+                    float angle = entity.rotationYaw;
+                    stack.rotate(Vector3f.ZN.rotationDegrees(angle));
+                    stack.translate(0, -(4 * 0.0626), 0);
+                    stack.translate(0, 0, -0.0626 / 4);
+                    stack.rotate(Vector3f.YP.rotationDegrees(90));
+                    Minecraft.getInstance().getItemRenderer().renderItem(itemStack,
+                            ItemCameraTransforms.TransformType.GROUND, p_225628_3_, OverlayTexture.NO_OVERLAY, stack,
+                            type);
+                    stack.pop();
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
+++ b/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
@@ -1,5 +1,6 @@
 package com.blamejared.slimyboyos.client.render;
 
+import com.blamejared.slimyboyos.capability.SlimeAbsorptionCapability;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
@@ -10,11 +11,9 @@ import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.vector.Vector3f;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.common.util.Constants;
 
 @OnlyIn(Dist.CLIENT)
 public class SlimeItemLayer<T extends Entity> extends LayerRenderer<T, SlimeModel<T>> {
@@ -26,9 +25,8 @@ public class SlimeItemLayer<T extends Entity> extends LayerRenderer<T, SlimeMode
     public void render(MatrixStack stack, IRenderTypeBuffer type, int p_225628_3_, T entity, float p_225628_5_,
                        float p_225628_6_, float p_225628_7_, float p_225628_8_, float p_225628_9_, float p_225628_10_) {
         if (entity.isAlive() && !entity.isInvisible()) {
-            CompoundNBT data = entity.getPersistentData();
-            if (data.contains("AbsorbedItem", Constants.NBT.TAG_COMPOUND)) {
-                ItemStack itemStack = ItemStack.read(data.getCompound("AbsorbedItem"));
+            entity.getCapability(SlimeAbsorptionCapability.SLIME_ABSORPTION).ifPresent(slimeAbsorption -> {
+                ItemStack itemStack = slimeAbsorption.getAbsorbedStack();
                 if (!itemStack.isEmpty()) {
                     stack.push();
                     stack.rotate(Vector3f.XP.rotationDegrees(180));
@@ -42,7 +40,7 @@ public class SlimeItemLayer<T extends Entity> extends LayerRenderer<T, SlimeMode
                             type);
                     stack.pop();
                 }
-            }
+            });
         }
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
+++ b/src/main/java/com/blamejared/slimyboyos/client/render/SlimeItemLayer.java
@@ -34,8 +34,6 @@ public class SlimeItemLayer<T extends Entity> extends LayerRenderer<T, SlimeMode
                     stack.rotate(Vector3f.XP.rotationDegrees(180));
                     stack.translate(0, -1, 0);
                     stack.rotate(Vector3f.XP.rotationDegrees(90));
-                    float angle = entity.rotationYaw;
-                    stack.rotate(Vector3f.ZN.rotationDegrees(angle));
                     stack.translate(0, -(4 * 0.0626), 0);
                     stack.translate(0, 0, -0.0626 / 4);
                     stack.rotate(Vector3f.YP.rotationDegrees(90));

--- a/src/main/java/com/blamejared/slimyboyos/events/ClientEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/ClientEventHandler.java
@@ -2,18 +2,22 @@ package com.blamejared.slimyboyos.events;
 
 import com.blamejared.slimyboyos.client.render.SlimeItemLayer;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.entity.*;
+import net.minecraft.client.renderer.entity.EntityRendererManager;
+import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraftforge.client.event.RecipesUpdatedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public class ClientEventHandler {
-    
+
     @SubscribeEvent
     public void recipeUpdated(RecipesUpdatedEvent e) {
         EntityRendererManager manager = Minecraft.getInstance().getRenderManager();
-        ForgeRegistries.ENTITIES.getValues().stream().filter(entityType -> entityType.getTags().contains(CommonEventHandler.SLIMES)).map(manager.renderers::get).filter(entityRenderer -> entityRenderer instanceof MobRenderer).map(entityRenderer -> (MobRenderer) entityRenderer).forEach(mobRenderer -> {
-            mobRenderer.addLayer(new SlimeItemLayer(mobRenderer));
-        });
+        ForgeRegistries.ENTITIES.getValues().stream()
+                .filter(entityType -> entityType.getTags().contains(CommonEventHandler.SLIMES))
+                .map(manager.renderers::get)
+                .filter(entityRenderer -> entityRenderer instanceof MobRenderer)
+                .map(entityRenderer -> (MobRenderer<?, ?>) entityRenderer)
+                .forEach(mobRenderer -> mobRenderer.addLayer(new SlimeItemLayer(mobRenderer)));
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/events/ClientEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/ClientEventHandler.java
@@ -1,20 +1,24 @@
 package com.blamejared.slimyboyos.events;
 
+import com.blamejared.slimyboyos.SlimyBoyos;
 import com.blamejared.slimyboyos.client.render.SlimeItemLayer;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.entity.*;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.client.renderer.entity.EntityRendererManager;
+import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraftforge.client.event.RecipesUpdatedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public class ClientEventHandler {
-    
+
     @SubscribeEvent
     public void recipeUpdated(RecipesUpdatedEvent e) {
         EntityRendererManager manager = Minecraft.getInstance().getRenderManager();
-        ForgeRegistries.ENTITIES.getValues().stream().filter(entityType -> entityType.getTags().contains(new ResourceLocation("forge:slimes"))).map(manager.renderers::get).filter(entityRenderer -> entityRenderer instanceof MobRenderer).map(entityRenderer -> (MobRenderer) entityRenderer).forEach(mobRenderer -> {
-            mobRenderer.addLayer(new SlimeItemLayer(mobRenderer));
-        });
+        ForgeRegistries.ENTITIES.getValues().stream()
+                .filter(entityType -> entityType.getTags().contains(SlimyBoyos.SLIMES))
+                .map(manager.renderers::get)
+                .filter(entityRenderer -> entityRenderer instanceof MobRenderer)
+                .map(entityRenderer -> (MobRenderer<?, ?>) entityRenderer)
+                .forEach(mobRenderer -> mobRenderer.addLayer(new SlimeItemLayer(mobRenderer)));
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/events/ClientEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/ClientEventHandler.java
@@ -3,7 +3,6 @@ package com.blamejared.slimyboyos.events;
 import com.blamejared.slimyboyos.client.render.SlimeItemLayer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.*;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.RecipesUpdatedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -13,7 +12,7 @@ public class ClientEventHandler {
     @SubscribeEvent
     public void recipeUpdated(RecipesUpdatedEvent e) {
         EntityRendererManager manager = Minecraft.getInstance().getRenderManager();
-        ForgeRegistries.ENTITIES.getValues().stream().filter(entityType -> entityType.getTags().contains(new ResourceLocation("forge:slimes"))).map(manager.renderers::get).filter(entityRenderer -> entityRenderer instanceof MobRenderer).map(entityRenderer -> (MobRenderer) entityRenderer).forEach(mobRenderer -> {
+        ForgeRegistries.ENTITIES.getValues().stream().filter(entityType -> entityType.getTags().contains(CommonEventHandler.SLIMES)).map(manager.renderers::get).filter(entityRenderer -> entityRenderer instanceof MobRenderer).map(entityRenderer -> (MobRenderer) entityRenderer).forEach(mobRenderer -> {
             mobRenderer.addLayer(new SlimeItemLayer(mobRenderer));
         });
     }

--- a/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
@@ -57,7 +57,7 @@ public class CommonEventHandler {
     @SubscribeEvent
     public void onLivingDrops(LivingDropsEvent event) {
         LivingEntity living = event.getEntityLiving();
-        if (living.world.isRemote) {
+        if (living.world.isRemote || !living.world.getGameRules().getBoolean(GameRules.DO_MOB_LOOT)) {
             return;
         }
 

--- a/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
@@ -1,16 +1,19 @@
 package com.blamejared.slimyboyos.events;
 
-import com.blamejared.slimyboyos.SlimyBoyos;
-import com.blamejared.slimyboyos.network.MessageItemSync;
+import com.blamejared.slimyboyos.capability.SlimeAbsorption;
+import com.blamejared.slimyboyos.capability.SlimeAbsorptionCapability;
+import com.blamejared.slimyboyos.network.MessageItemPickup;
 import com.blamejared.slimyboyos.network.PacketHandler;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.network.PacketDistributor;
 
@@ -22,50 +25,57 @@ public class CommonEventHandler {
     @SubscribeEvent
     public void onLivingUpdate(LivingEvent.LivingUpdateEvent event) {
         LivingEntity living = event.getEntityLiving();
-        if (living.world.isRemote || !living.isAlive() || !living.getType().getTags().contains(SlimyBoyos.SLIMES)) {
+        if (living.world.isRemote || !living.isAlive() || !living.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
             return;
         }
 
-        CompoundNBT data = living.getPersistentData();
-        if (data.contains("AbsorbedItem")) {
-            return;
-        }
-
-        AxisAlignedBB bb = event.getEntity().getBoundingBox();
-        List<ItemEntity> list = event.getEntity().world.getEntitiesWithinAABB(ItemEntity.class, bb,
-                item -> item.isAlive() && !item.cannotPickup() && !item.getItem().isEmpty());
-        if (!list.isEmpty()) {
-            ItemEntity item = list.get(0);
-            ItemStack stack = item.getItem();
-
-            int collectedAmount = 1;
-            ItemStack absorbedStack = stack.split(collectedAmount);
-            data.put("AbsorbedItem", absorbedStack.serializeNBT());
-            PacketHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(event::getEntity),
-                    new MessageItemSync(item.getEntityId(), living.getEntityId(), collectedAmount));
-
-            if (stack.isEmpty()) {
-                item.remove();
+        living.getCapability(SlimeAbsorptionCapability.SLIME_ABSORPTION).ifPresent(slimeAbsorption -> {
+            if (!slimeAbsorption.getAbsorbedStack().isEmpty()) {
+                return;
             }
-        }
+            AxisAlignedBB bb = living.getBoundingBox();
+            List<ItemEntity> list = living.world.getEntitiesWithinAABB(ItemEntity.class, bb,
+                    item -> item.isAlive() && !item.cannotPickup() && !item.getItem().isEmpty());
+            if (!list.isEmpty()) {
+                ItemEntity item = list.get(0);
+                ItemStack stack = item.getItem();
+
+                ItemStack absorbedStack = stack.split(1);
+                slimeAbsorption.setAbsorbedStack(absorbedStack);
+                PacketHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(event::getEntity),
+                        new MessageItemPickup(item.getEntityId(), living.getEntityId(), absorbedStack.copy()));
+
+                if (stack.isEmpty()) {
+                    item.remove();
+                }
+            }
+        });
     }
 
     @SubscribeEvent
     public void onLivingDrops(LivingDropsEvent event) {
         LivingEntity living = event.getEntityLiving();
-        if (living.world.isRemote || !living.getType().getTags().contains(SlimyBoyos.SLIMES)) {
+        if (living.world.isRemote) {
             return;
         }
 
-        CompoundNBT data = living.getPersistentData();
-        ItemStack stack = ItemStack.read(data.getCompound("AbsorbedItem"));
-        data.remove("AbsorbedItem");
+        living.getCapability(SlimeAbsorptionCapability.SLIME_ABSORPTION).ifPresent(slimeAbsorption -> {
+            ItemStack stack = slimeAbsorption.getAbsorbedStack();
+            if (!stack.isEmpty()) {
+                World world = living.world;
+                ItemEntity item = new ItemEntity(world, living.getPosX(), living.getPosY(), living.getPosZ(),
+                        stack.copy());
+                item.setDefaultPickupDelay();
+                event.getDrops().add(item);
+            }
+        });
+    }
 
-        if (!stack.isEmpty()) {
-            World world = living.world;
-            ItemEntity item = new ItemEntity(world, living.getPosX(), living.getPosY(), living.getPosZ(), stack.copy());
-            item.setDefaultPickupDelay();
-            event.getDrops().add(item);
-        }
+    @SubscribeEvent
+    public void onCheckDespawn(LivingSpawnEvent.AllowDespawn event) {
+        event.getEntity().getCapability(SlimeAbsorptionCapability.SLIME_ABSORPTION)
+                .lazyMap(SlimeAbsorption::getAbsorbedStack)
+                .filter(stack -> !stack.isEmpty())
+                .ifPresent(stack -> event.setResult(Event.Result.DENY));
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
@@ -1,16 +1,16 @@
 package com.blamejared.slimyboyos.events;
 
-import com.blamejared.slimyboyos.network.*;
-import net.minecraft.entity.*;
+import com.blamejared.slimyboyos.SlimyBoyos;
+import com.blamejared.slimyboyos.network.MessageItemSync;
+import com.blamejared.slimyboyos.network.PacketHandler;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.ItemEntity;
-import net.minecraft.entity.monster.*;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.world.World;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.living.*;
+import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.network.PacketDistributor;
 
@@ -18,60 +18,54 @@ import java.util.List;
 
 
 public class CommonEventHandler {
-    
-    public static final ResourceLocation SLIMES = new ResourceLocation("forge:slimes");
-    
-    public CommonEventHandler() {
-        MinecraftForge.EVENT_BUS.register(this);
-    }
-    
+
     @SubscribeEvent
     public void onLivingUpdate(LivingEvent.LivingUpdateEvent event) {
-        if(event.getEntity().world.isRemote) {
+        LivingEntity living = event.getEntityLiving();
+        if (living.world.isRemote || !living.isAlive() || !living.getType().getTags().contains(SlimyBoyos.SLIMES)) {
             return;
         }
-        
-        if(event.getEntity().getType().getTags().contains(SLIMES)) {
-            if(!event.getEntityLiving().isAlive()) {
-                return;
-            }
-            CompoundNBT data = event.getEntityLiving().getPersistentData();
-            if(data.contains("AbsorbedItem")) {
-                return;
-            }
-            AxisAlignedBB bb = event.getEntity().getBoundingBox();
-            List<ItemEntity> list = event.getEntity().world.getEntitiesWithinAABB(ItemEntity.class, bb);
-            if(!list.isEmpty()) {
-                if(list.get(0).cannotPickup()) {
-                    return;
-                }
-                ItemStack newItem = list.get(0).getItem().copy();
-                newItem.setCount(1);
-                data.put("AbsorbedItem", newItem.serializeNBT());
-                PacketHandler.CHANNEL.send(PacketDistributor.NEAR.with(() -> new PacketDistributor.TargetPoint(event.getEntityLiving().getPosX(), event.getEntityLiving().getPosY(), event.getEntityLiving().getPosZ(), 128, event.getEntityLiving().world.getDimensionKey())), new MessageItemSync(newItem, event.getEntity().getEntityId()));//sendToAllAround(new MessageEntitySync((EntitySlime) event.getEntityLiving()), new NetworkRegistry.TargetPoint(event.getEntity().world.provider.getDimension(), event.getEntity().posX, event.getEntity().posY, event.getEntity().posZ, 128D));
-                list.get(0).getItem().shrink(1);
-                if(list.get(0).getItem().getCount() <= 0) {
-                    list.get(0).remove();
-                }
+
+        CompoundNBT data = living.getPersistentData();
+        if (data.contains("AbsorbedItem")) {
+            return;
+        }
+
+        AxisAlignedBB bb = event.getEntity().getBoundingBox();
+        List<ItemEntity> list = event.getEntity().world.getEntitiesWithinAABB(ItemEntity.class, bb,
+                item -> item.isAlive() && !item.cannotPickup() && !item.getItem().isEmpty());
+        if (!list.isEmpty()) {
+            ItemEntity item = list.get(0);
+            ItemStack stack = item.getItem();
+
+            int collectedAmount = 1;
+            ItemStack absorbedStack = stack.split(collectedAmount);
+            data.put("AbsorbedItem", absorbedStack.serializeNBT());
+            PacketHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(event::getEntity),
+                    new MessageItemSync(item.getEntityId(), living.getEntityId(), collectedAmount));
+
+            if (stack.isEmpty()) {
+                item.remove();
             }
         }
     }
-    
+
     @SubscribeEvent
     public void onLivingDrops(LivingDropsEvent event) {
-        if(event.getEntity().world.isRemote) {
+        LivingEntity living = event.getEntityLiving();
+        if (living.world.isRemote || !living.getType().getTags().contains(SlimyBoyos.SLIMES)) {
             return;
         }
-        if(event.getEntity().getType().getTags().contains(SLIMES)) {
-            LivingEntity base = event.getEntityLiving();
-            CompoundNBT data = base.getPersistentData();
-            ItemStack stack = ItemStack.read(data.getCompound("AbsorbedItem"));
-            if(!stack.isEmpty()) {
-                World world = base.world;
-                ItemEntity entityitem = new ItemEntity(world, base.getPosX(), base.getPosY() + 1, base.getPosZ(), stack.copy());
-                entityitem.setPickupDelay(20);
-                world.addEntity(entityitem);
-            }
+
+        CompoundNBT data = living.getPersistentData();
+        ItemStack stack = ItemStack.read(data.getCompound("AbsorbedItem"));
+        data.remove("AbsorbedItem");
+
+        if (!stack.isEmpty()) {
+            World world = living.world;
+            ItemEntity item = new ItemEntity(world, living.getPosX(), living.getPosY(), living.getPosZ(), stack.copy());
+            item.setDefaultPickupDelay();
+            event.getDrops().add(item);
         }
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
@@ -1,5 +1,6 @@
 package com.blamejared.slimyboyos.events;
 
+import com.blamejared.slimyboyos.SlimyBoyos;
 import com.blamejared.slimyboyos.network.MessageItemSync;
 import com.blamejared.slimyboyos.network.PacketHandler;
 import net.minecraft.entity.LivingEntity;
@@ -8,9 +9,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.network.PacketDistributor;
 
@@ -24,50 +27,57 @@ public class CommonEventHandler {
     @SubscribeEvent
     public void onLivingUpdate(LivingEvent.LivingUpdateEvent event) {
         LivingEntity living = event.getEntityLiving();
-        if (living.world.isRemote || !living.isAlive() || !living.getType().getTags().contains(SlimyBoyos.SLIMES)) {
+        if (living.world.isRemote || !living.isAlive() || !living.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
             return;
         }
 
-        CompoundNBT data = living.getPersistentData();
-        if (data.contains("AbsorbedItem")) {
-            return;
-        }
-
-        AxisAlignedBB bb = event.getEntity().getBoundingBox();
-        List<ItemEntity> list = event.getEntity().world.getEntitiesWithinAABB(ItemEntity.class, bb,
-                item -> item.isAlive() && !item.cannotPickup() && !item.getItem().isEmpty());
-        if (!list.isEmpty()) {
-            ItemEntity item = list.get(0);
-            ItemStack stack = item.getItem();
-
-            int collectedAmount = 1;
-            ItemStack absorbedStack = stack.split(collectedAmount);
-            data.put("AbsorbedItem", absorbedStack.serializeNBT());
-            PacketHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(event::getEntity),
-                    new MessageItemSync(item.getEntityId(), living.getEntityId(), collectedAmount));
-
-            if (stack.isEmpty()) {
-                item.remove();
+        living.getCapability(SlimeAbsorptionCapability.SLIME_ABSORPTION).ifPresent(slimeAbsorption -> {
+            if (!slimeAbsorption.getAbsorbedStack().isEmpty()) {
+                return;
             }
-        }
+            AxisAlignedBB bb = living.getBoundingBox();
+            List<ItemEntity> list = living.world.getEntitiesWithinAABB(ItemEntity.class, bb,
+                    item -> item.isAlive() && !item.cannotPickup() && !item.getItem().isEmpty());
+            if (!list.isEmpty()) {
+                ItemEntity item = list.get(0);
+                ItemStack stack = item.getItem();
+
+                ItemStack absorbedStack = stack.split(1);
+                slimeAbsorption.setAbsorbedStack(absorbedStack);
+                PacketHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(event::getEntity),
+                        new MessageItemPickup(item.getEntityId(), living.getEntityId(), absorbedStack.copy()));
+
+                if (stack.isEmpty()) {
+                    item.remove();
+                }
+            }
+        });
     }
 
     @SubscribeEvent
     public void onLivingDrops(LivingDropsEvent event) {
         LivingEntity living = event.getEntityLiving();
-        if (living.world.isRemote || !living.getType().getTags().contains(SLIMES)) {
+        if (living.world.isRemote) {
             return;
         }
 
-        CompoundNBT data = living.getPersistentData();
-        ItemStack stack = ItemStack.read(data.getCompound("AbsorbedItem"));
-        data.remove("AbsorbedItem");
+        living.getCapability(SlimeAbsorptionCapability.SLIME_ABSORPTION).ifPresent(slimeAbsorption -> {
+            ItemStack stack = slimeAbsorption.getAbsorbedStack();
+            if (!stack.isEmpty()) {
+                World world = living.world;
+                ItemEntity item = new ItemEntity(world, living.getPosX(), living.getPosY(), living.getPosZ(),
+                        stack.copy());
+                item.setDefaultPickupDelay();
+                event.getDrops().add(item);
+            }
+        });
+    }
 
-        if (!stack.isEmpty()) {
-            World world = living.world;
-            ItemEntity item = new ItemEntity(world, living.getPosX(), living.getPosY(), living.getPosZ(), stack.copy());
-            item.setDefaultPickupDelay();
-            event.getDrops().add(item);
-        }
+    @SubscribeEvent
+    public void onCheckDespawn(LivingSpawnEvent.AllowDespawn event) {
+        event.getEntity().getCapability(SlimeAbsorptionCapability.SLIME_ABSORPTION)
+                .lazyMap(SlimeAbsorption::getAbsorbedStack)
+                .filter(stack -> !stack.isEmpty())
+                .ifPresent(stack -> event.setResult(Event.Result.DENY));
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
@@ -1,19 +1,16 @@
 package com.blamejared.slimyboyos.events;
 
-import com.blamejared.slimyboyos.network.*;
-import net.minecraft.entity.*;
+import com.blamejared.slimyboyos.network.MessageItemSync;
+import com.blamejared.slimyboyos.network.PacketHandler;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.ItemEntity;
-import net.minecraft.entity.monster.*;
-import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.living.*;
-import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.network.PacketDistributor;
 
@@ -21,74 +18,56 @@ import java.util.List;
 
 
 public class CommonEventHandler {
-    
+
     public static final ResourceLocation SLIMES = new ResourceLocation("forge:slimes");
-    
-    public CommonEventHandler() {
-        MinecraftForge.EVENT_BUS.register(this);
-    }
-    
+
     @SubscribeEvent
     public void onLivingUpdate(LivingEvent.LivingUpdateEvent event) {
-        if(event.getEntity().world.isRemote) {
+        LivingEntity living = event.getEntityLiving();
+        if (living.world.isRemote || !living.isAlive() || !living.getType().getTags().contains(SlimyBoyos.SLIMES)) {
             return;
         }
-        
-        if(event.getEntity().getType().getTags().contains(SLIMES)) {
-            if(!event.getEntityLiving().isAlive()) {
-                return;
-            }
-            CompoundNBT data = event.getEntityLiving().getPersistentData();
-            if(data.contains("AbsorbedItem")) {
-                return;
-            }
-            AxisAlignedBB bb = event.getEntity().getBoundingBox();
-            List<ItemEntity> list = event.getEntity().world.getEntitiesWithinAABB(ItemEntity.class, bb);
-            if(!list.isEmpty()) {
-                if(list.get(0).cannotPickup()) {
-                    return;
-                }
-                ItemStack newItem = list.get(0).getItem().copy();
-                newItem.setCount(1);
-                data.put("AbsorbedItem", newItem.serializeNBT());
-                PacketHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(() -> event.getEntity()), new MessageItemSync(newItem, event.getEntity().getEntityId()));//sendToAllAround(new MessageEntitySync((EntitySlime) event.getEntityLiving()), new NetworkRegistry.TargetPoint(event.getEntity().world.provider.getDimension(), event.getEntity().posX, event.getEntity().posY, event.getEntity().posZ, 128D));
-                list.get(0).getItem().shrink(1);
-                if(list.get(0).getItem().getCount() <= 0) {
-                    list.get(0).remove();
-                }
+
+        CompoundNBT data = living.getPersistentData();
+        if (data.contains("AbsorbedItem")) {
+            return;
+        }
+
+        AxisAlignedBB bb = event.getEntity().getBoundingBox();
+        List<ItemEntity> list = event.getEntity().world.getEntitiesWithinAABB(ItemEntity.class, bb,
+                item -> item.isAlive() && !item.cannotPickup() && !item.getItem().isEmpty());
+        if (!list.isEmpty()) {
+            ItemEntity item = list.get(0);
+            ItemStack stack = item.getItem();
+
+            int collectedAmount = 1;
+            ItemStack absorbedStack = stack.split(collectedAmount);
+            data.put("AbsorbedItem", absorbedStack.serializeNBT());
+            PacketHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(event::getEntity),
+                    new MessageItemSync(item.getEntityId(), living.getEntityId(), collectedAmount));
+
+            if (stack.isEmpty()) {
+                item.remove();
             }
         }
     }
-    
-    @SubscribeEvent
-    public void onStartEntityTracking(PlayerEvent.StartTracking event) {
-        if(event.getEntity().world.isRemote || !event.getTarget().isAlive()) {
-            return;
-        }
-        if(event.getTarget().getType().getTags().contains(SLIMES)) {
-            CompoundNBT data = event.getTarget().getPersistentData();
-            ItemStack stack = ItemStack.read(data.getCompound("AbsorbedItem"));
-            if(!stack.isEmpty()) {
-                PacketHandler.CHANNEL.send(PacketDistributor.PLAYER.with(() -> (ServerPlayerEntity) event.getPlayer()), new MessageItemSync(stack, event.getTarget().getEntityId()));
-            }
-        }
-    }
-    
+
     @SubscribeEvent
     public void onLivingDrops(LivingDropsEvent event) {
-        if(event.getEntity().world.isRemote) {
+        LivingEntity living = event.getEntityLiving();
+        if (living.world.isRemote || !living.getType().getTags().contains(SLIMES)) {
             return;
         }
-        if(event.getEntity().getType().getTags().contains(SLIMES)) {
-            LivingEntity base = event.getEntityLiving();
-            CompoundNBT data = base.getPersistentData();
-            ItemStack stack = ItemStack.read(data.getCompound("AbsorbedItem"));
-            World world = base.world;
-            if(!stack.isEmpty() && world.getGameRules().getBoolean(GameRules.DO_ENTITY_DROPS)) {
-                ItemEntity entityitem = new ItemEntity(world, base.getPosX(), base.getPosY() + 1, base.getPosZ(), stack.copy());
-                entityitem.setPickupDelay(20);
-                world.addEntity(entityitem);
-            }
+
+        CompoundNBT data = living.getPersistentData();
+        ItemStack stack = ItemStack.read(data.getCompound("AbsorbedItem"));
+        data.remove("AbsorbedItem");
+
+        if (!stack.isEmpty()) {
+            World world = living.world;
+            ItemEntity item = new ItemEntity(world, living.getPosX(), living.getPosY(), living.getPosZ(), stack.copy());
+            item.setDefaultPickupDelay();
+            event.getDrops().add(item);
         }
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/events/CommonEventHandler.java
@@ -55,7 +55,7 @@ public class CommonEventHandler {
     @SubscribeEvent
     public void onLivingDrops(LivingDropsEvent event) {
         LivingEntity living = event.getEntityLiving();
-        if (living.world.isRemote) {
+        if (living.world.isRemote || !living.world.getGameRules().getBoolean(GameRules.DO_MOB_LOOT)) {
             return;
         }
 

--- a/src/main/java/com/blamejared/slimyboyos/network/MessageItemPickup.java
+++ b/src/main/java/com/blamejared/slimyboyos/network/MessageItemPickup.java
@@ -1,0 +1,16 @@
+package com.blamejared.slimyboyos.network;
+
+import net.minecraft.item.ItemStack;
+
+public class MessageItemPickup {
+
+    public final int collectedItemEntityId;
+    public final int collectorEntityId;
+    public final ItemStack absorbedStack;
+
+    public MessageItemPickup(int collectedItemEntityId, int collectorEntityId, ItemStack absorbedStack) {
+        this.collectedItemEntityId = collectedItemEntityId;
+        this.collectorEntityId = collectorEntityId;
+        this.absorbedStack = absorbedStack;
+    }
+}

--- a/src/main/java/com/blamejared/slimyboyos/network/MessageItemSync.java
+++ b/src/main/java/com/blamejared/slimyboyos/network/MessageItemSync.java
@@ -1,14 +1,14 @@
 package com.blamejared.slimyboyos.network;
 
-import net.minecraft.item.ItemStack;
-
 public class MessageItemSync {
-    
-    public final ItemStack stack;
-    public final int entityId;
-    
-    public MessageItemSync(ItemStack stack, int entityId) {
-        this.stack = stack;
-        this.entityId = entityId;
+
+    public final int collectedItemEntityId;
+    public final int collectorEntityId;
+    public final int collectedAmount;
+
+    public MessageItemSync(int collectedItemEntityId, int collectorEntityId, int collectedAmount) {
+        this.collectedItemEntityId = collectedItemEntityId;
+        this.collectorEntityId = collectorEntityId;
+        this.collectedAmount = collectedAmount;
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/network/MessageItemSync.java
+++ b/src/main/java/com/blamejared/slimyboyos/network/MessageItemSync.java
@@ -1,14 +1,14 @@
 package com.blamejared.slimyboyos.network;
 
+import net.minecraft.item.ItemStack;
+
 public class MessageItemSync {
 
-    public final int collectedItemEntityId;
-    public final int collectorEntityId;
-    public final int collectedAmount;
+    public final int entityId;
+    public final ItemStack absorbedStack;
 
-    public MessageItemSync(int collectedItemEntityId, int collectorEntityId, int collectedAmount) {
-        this.collectedItemEntityId = collectedItemEntityId;
-        this.collectorEntityId = collectorEntityId;
-        this.collectedAmount = collectedAmount;
+    public MessageItemSync(int entityId, ItemStack absorbedStack) {
+        this.entityId = entityId;
+        this.absorbedStack = absorbedStack;
     }
 }

--- a/src/main/java/com/blamejared/slimyboyos/network/PacketHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/network/PacketHandler.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.network.NetworkRegistry;
 import net.minecraftforge.fml.network.simple.SimpleChannel;
 
@@ -32,6 +33,10 @@ public class PacketHandler {
                 (msg, ctx) -> ctx.get().enqueueWork(() -> {
                     Minecraft mc = Minecraft.getInstance();
                     ClientWorld w = mc.world;
+                    if (w == null) {
+                        return;
+                    }
+
                     Entity collected = w.getEntityByID(msg.collectedItemEntityId);
                     Entity collector = w.getEntityByID(msg.collectorEntityId);
 
@@ -58,12 +63,18 @@ public class PacketHandler {
                 },
                 pb -> new MessageItemSync(pb.readVarInt(), pb.readItemStack()),
                 (msg, ctx) -> ctx.get().enqueueWork(() -> {
-                    Entity e = Minecraft.getInstance().world.getEntityByID(msg.entityId);
-
-                    if (e != null) {
-                        e.getCapability(SlimeAbsorptionCapability.SLIME_ABSORPTION)
-                                .ifPresent(slimeAbsorption -> slimeAbsorption.setAbsorbedStack(msg.absorbedStack));
+                    World w = Minecraft.getInstance().world;
+                    if (w == null) {
+                        return;
                     }
+
+                    Entity e = w.getEntityByID(msg.entityId);
+                    if (e == null) {
+                        return;
+                    }
+
+                    e.getCapability(SlimeAbsorptionCapability.SLIME_ABSORPTION)
+                            .ifPresent(slimeAbsorption -> slimeAbsorption.setAbsorbedStack(msg.absorbedStack));
                 }));
     }
 

--- a/src/main/java/com/blamejared/slimyboyos/network/PacketHandler.java
+++ b/src/main/java/com/blamejared/slimyboyos/network/PacketHandler.java
@@ -1,24 +1,59 @@
 package com.blamejared.slimyboyos.network;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.util.*;
+import net.minecraft.client.particle.ItemPickupParticle;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.ItemEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
 import net.minecraftforge.fml.network.NetworkRegistry;
 import net.minecraftforge.fml.network.simple.SimpleChannel;
 
 public class PacketHandler {
-    
-    public static SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(new ResourceLocation("slimyboyos:main"), () -> "3.0.0", "3.0.0"::equals, "3.0.0"::equals);
-    
+
+    public static SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(new ResourceLocation("slimyboyos:main"),
+            () -> "3.1.0", "3.1.0"::equals, "3.1.0"::equals);
+
     private static int ID = 0;
-    
+
     public static void init() {
-        CHANNEL.registerMessage(ID++, MessageItemSync.class, (messageItemSync, packetBuffer) -> {
-            packetBuffer.writeItemStack(messageItemSync.stack);
-            packetBuffer.writeInt(messageItemSync.entityId);
-        }, packetBuffer -> new MessageItemSync(packetBuffer.readItemStack(), packetBuffer.readInt()), (messageItemSync, contextSupplier) -> contextSupplier.get().enqueueWork(() -> {
-            Minecraft.getInstance().world.getEntityByID(messageItemSync.entityId).getPersistentData().put("AbsorbedItem",messageItemSync.stack.serializeNBT());
-        }));
+        CHANNEL.registerMessage(
+                ID++,
+                MessageItemSync.class,
+                (msg, pb) -> {
+                    pb.writeVarInt(msg.collectedItemEntityId);
+                    pb.writeVarInt(msg.collectorEntityId);
+                    pb.writeVarInt(msg.collectedAmount);
+                },
+                pb -> new MessageItemSync(pb.readVarInt(), pb.readVarInt(), pb.readVarInt()),
+                (msg, ctx) -> ctx.get().enqueueWork(() -> {
+                    Minecraft mc = Minecraft.getInstance();
+                    ClientWorld w = mc.world;
+                    Entity collected = w.getEntityByID(msg.collectedItemEntityId);
+                    Entity collector = w.getEntityByID(msg.collectorEntityId);
+
+                    if (collector != null && collected instanceof ItemEntity) {
+                        ItemEntity item = (ItemEntity) collected;
+
+                        w.playSound(item.getPosX(), item.getPosY(), item.getPosZ(),
+                                SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS,
+                                0.2F, (w.rand.nextFloat() - w.rand.nextFloat()) * 1.4F + 2.0F, false);
+                        mc.particles.addEffect(new ItemPickupParticle(mc.getRenderManager(),
+                                mc.getRenderTypeBuffers(), w, item, collector));
+
+                        ItemStack stack = item.getItem();
+                        ItemStack pickup = stack.split(msg.collectedAmount);
+                        collector.getPersistentData().put("AbsorbedItem", pickup.serializeNBT());
+
+                        if (stack.isEmpty()) {
+                            w.removeEntityFromWorld(msg.collectedItemEntityId);
+                        }
+                    }
+                }));
     }
-    
-    
+
+
 }

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "description": "SlimeyBoyos Resources",
-        "pack_format": 4
+        "description": "SlimyBoyos Resources",
+        "pack_format": 6
     }
 }


### PR DESCRIPTION
- Fix rotation while rendering
- Fix doubly registered event handler
- Add pickup sounds & particles (copies from the vanilla pickup handler)
- Fix network sync (no more invisible items!)
- Switch over to Capabilities internally

These three fixes bring the absorption feature more in line with the vanilla monster equipment pickups:
- Only let the Slimes pick up items when the gamerule `MOB_GRIEFING` is activated
- Don't drop item when the gamerule `DO_MOB_LOOT` is deactivated
- Don't let Slimes despawn when they carry items