### PR TITLE
Fix logo not displaying on Forge.

### DIFF
--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -1,6 +1,9 @@
 modLoader="javafml"
 loaderVersion="[40,)"
 license="LGPL v2.1"
+logoFile="logo.png"
+logoBlur=false
+
 [[mods]]
 modId="slimyboyos"
 version="${file.jarVersion}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ subprojects {
                         "Implementation-Timestamp" to SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(Date()),
                         "Timestamp" to System.currentTimeMillis(),
                         "Built-On-Java" to "${System.getProperty("java.vm.version")} (${System.getProperty("java.vm.vendor")})",
-                        "Build-On-Minecraft" to minecraftVersion
+                        "Built-On-Minecraft" to minecraftVersion
                 )
             }
         }


### PR DESCRIPTION
The Forge JAR is already shipping the logo file however it's not being displayed on the mod list. This PR specifies the properties required to enable that and also enables compatibility for the Catalogue mod.